### PR TITLE
Test no scroll in scroll

### DIFF
--- a/src/CBTForm.tsx
+++ b/src/CBTForm.tsx
@@ -74,9 +74,6 @@ export default class CBTForm extends React.Component<Props> {
         <FormContainer>
           <SubHeader>Cognitive Distortion</SubHeader>
           <RoundedSelector
-            style={{
-              height: 150,
-            }}
             items={thought.cognitiveDistortions}
             onPress={onSelectCognitiveDistortion}
           />

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -125,7 +125,7 @@ SelectorTextItem.propTypes = {
 };
 
 export const RoundedSelector = ({ items, onPress, style }) => (
-  <ScrollView
+  <View
     style={{
       backgroundColor: "white",
       borderRadius: 8,
@@ -149,7 +149,7 @@ export const RoundedSelector = ({ items, onPress, style }) => (
         />
       );
     })}
-  </ScrollView>
+  </View>
 );
 
 RoundedSelector.propTypes = {


### PR DESCRIPTION
This PR is testing a non-scrollable cognitive distortion input. With this design, there's never a "scroll in scroll" issue with smaller phones, which should make it easier to handle and enter in.

<img width="952" alt="screen shot 2019-01-13 at 12 03 46 pm" src="https://user-images.githubusercontent.com/5942769/51090073-5181bb80-172b-11e9-90ce-4289579b5765.png">
