### PR TITLE
Add Alerts + Settings + Alternative Thought as label

### DIFF
--- a/App.ts
+++ b/App.ts
@@ -3,19 +3,22 @@ import {
   CBT_LIST_SCREEN,
   CBT_FORM_SCREEN,
   EXPLANATION_SCREEN,
+  SETTING_SCREEN,
 } from "./src/screens";
 import CBTListScreen from "./src/CBTListScreen";
 import CBTFormScreen from "./src/CBTFormScreen";
 import ExplanationScreen from "./src/ExplanationScreen";
+import SettingScreen from "./src/setting";
 
 const App = createStackNavigator(
   {
     [CBT_LIST_SCREEN]: CBTListScreen,
     [CBT_FORM_SCREEN]: CBTFormScreen,
     [EXPLANATION_SCREEN]: ExplanationScreen,
+    [SETTING_SCREEN]: SettingScreen,
   },
   {
-    initialRouteName: CBT_FORM_SCREEN,
+    initialRouteName: SETTING_SCREEN,
     mode: "modal",
   }
 );

--- a/App.ts
+++ b/App.ts
@@ -18,7 +18,7 @@ const App = createStackNavigator(
     [SETTING_SCREEN]: SettingScreen,
   },
   {
-    initialRouteName: SETTING_SCREEN,
+    initialRouteName: CBT_FORM_SCREEN,
     mode: "modal",
   }
 );

--- a/app.json
+++ b/app.json
@@ -5,7 +5,7 @@
     "privacy": "unlisted",
     "sdkVersion": "31.0.0",
     "platforms": ["ios", "android"],
-    "version": "1.5.0",
+    "version": "1.5.2",
     "orientation": "portrait",
     "githubUrl": "https://github.com/Flaque/quirk",
     "primaryColor": "#F8A5C2",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-native": "https://github.com/expo/react-native/archive/sdk-31.0.0.tar.gz",
     "react-native-autogrow-textinput": "^5.2.0",
     "react-native-keyboard-aware-scroll-view": "^0.7.4",
+    "react-native-pose": "^0.9.0",
     "react-native-svg": "^8.0.8",
     "react-native-swiper": "^1.5.14",
     "react-navigation": "^3.0.8",

--- a/src/CBTForm.tsx
+++ b/src/CBTForm.tsx
@@ -113,7 +113,7 @@ export default class CBTForm extends React.Component<Props> {
           />
         </FormContainer>
 
-        <Row justifyContent="flex-end">
+        <Row style={{ justifyContent: "flex-end" }}>
           <RoundedButton disabled={false} title="Save" onPress={onSave} />
         </Row>
       </View>

--- a/src/CBTListScreen.tsx
+++ b/src/CBTListScreen.tsx
@@ -25,7 +25,7 @@ import Alerter from "./alerter";
 import alerts from "./alerts";
 
 const ThoughtItem = ({ thought, onPress, onDelete }) => (
-  <Row marginBottom={18}>
+  <Row style={{ marginBottom: 18 }}>
     <TouchableOpacity
       style={{
         padding: 18,
@@ -154,6 +154,7 @@ class CBTListScreen extends React.Component<Props, State> {
 
     getExercises()
       .then(data => {
+        console.log(data);
         const thoughts: SavedThought[] = data
           .map(([_, value]) => JSON.parse(value))
           .filter(n => n) // Worst case scenario, if bad data gets in we don't show it.
@@ -208,8 +209,8 @@ class CBTListScreen extends React.Component<Props, State> {
         >
           <Container>
             <StatusBar barStyle="dark-content" />
-            <Row marginBottom={18}>
-              <Header>quirk.</Header>
+            <Row style={{ marginBottom: 18 }}>
+              <Header>.quirk</Header>
               <IconButton
                 featherIconName={"edit"}
                 onPress={() => this.navigateToForm()}

--- a/src/CBTListScreen.tsx
+++ b/src/CBTListScreen.tsx
@@ -7,11 +7,10 @@ import {
   View,
   Image,
 } from "react-native";
-import PropTypes from "prop-types";
 import { getExercises, deleteExercise } from "./store";
 import { Header, Row, Container, IconButton, Label } from "./ui";
 import theme from "./theme";
-import { CBT_FORM_SCREEN } from "./screens";
+import { CBT_FORM_SCREEN, SETTING_SCREEN } from "./screens";
 import { SavedThought, ThoughtGroup, groupThoughtsByDay } from "./thoughts";
 import {
   NavigationScreenProp,
@@ -25,7 +24,17 @@ import Alerter from "./alerter";
 import alerts from "./alerts";
 import { HistoryButtonLabelSetting, getHistoryButtonLabel } from "./setting";
 
-const ThoughtItem = ({ thought, historyButtonLabel, onPress, onDelete }) => (
+const ThoughtItem = ({
+  thought,
+  historyButtonLabel,
+  onPress,
+  onDelete,
+}: {
+  thought: SavedThought;
+  historyButtonLabel: HistoryButtonLabelSetting;
+  onPress: (thought: SavedThought | boolean) => void;
+  onDelete: (thought: SavedThought) => void;
+}) => (
   <Row style={{ marginBottom: 18 }}>
     <TouchableOpacity
       style={{
@@ -53,17 +62,14 @@ const ThoughtItem = ({ thought, historyButtonLabel, onPress, onDelete }) => (
     </TouchableOpacity>
 
     <IconButton
-      alignSelf={"flex-start"}
+      style={{
+        alignSelf: "flex-start",
+      }}
       featherIconName={"trash"}
       onPress={() => onDelete(thought)}
     />
   </Row>
 );
-
-ThoughtItem.propTypes = {
-  thought: PropTypes.object.isRequired,
-  onPress: PropTypes.func.isRequired,
-};
 
 const EmptyThoughtIllustration = () => (
   <View
@@ -146,6 +152,10 @@ class CBTListScreen extends React.Component<Props, State> {
   constructor(props) {
     super(props);
     this.state = { groups: [], historyButtonLabel: "alternative-thought" };
+
+    this.props.navigation.addListener("willFocus", () => {
+      this.loadSettings();
+    });
   }
 
   loadExercises = (): void => {
@@ -189,6 +199,10 @@ class CBTListScreen extends React.Component<Props, State> {
     }, 100);
   };
 
+  navigateToSettings = () => {
+    this.props.navigation.navigate(SETTING_SCREEN);
+  };
+
   navigateToForm = () => {
     this.navigateToFormWithThought(false);
   };
@@ -224,16 +238,25 @@ class CBTListScreen extends React.Component<Props, State> {
             <StatusBar barStyle="dark-content" />
             <Row style={{ marginBottom: 18 }}>
               <Header>.quirk</Header>
-              <IconButton
-                featherIconName={"edit"}
-                onPress={() => this.navigateToForm()}
-              />
+
+              <View style={{ flexDirection: "row" }}>
+                <IconButton
+                  featherIconName={"settings"}
+                  onPress={() => this.navigateToSettings()}
+                  style={{ marginRight: 18 }}
+                />
+                <IconButton
+                  featherIconName={"edit"}
+                  onPress={() => this.navigateToForm()}
+                />
+              </View>
             </Row>
 
             <ThoughtItemList
               groups={groups}
               navigateToFormWithThought={this.navigateToFormWithThought}
               onItemDelete={this.onItemDelete}
+              historyButtonLabel={historyButtonLabel}
             />
           </Container>
         </ScrollView>

--- a/src/CBTListScreen.tsx
+++ b/src/CBTListScreen.tsx
@@ -45,7 +45,7 @@ const ThoughtItem = ({ thought, onPress, onDelete }) => (
           fontSize: 16,
         }}
       >
-        {thought.automaticThought}
+        {thought.alternativeThought}
       </Text>
     </TouchableOpacity>
 

--- a/src/CBTListScreen.tsx
+++ b/src/CBTListScreen.tsx
@@ -230,7 +230,14 @@ class CBTListScreen extends React.Component<Props, State> {
             />
           </Container>
         </ScrollView>
-        <Alert title={"Hey-o!"} body={"We changed some stuff!"} />
+        <Alert
+          title={"👋 Hey-o!"}
+          body={`Something's changed!
+
+Thoughts shown here are now the alternative thought, not your initial thought. We changed this to cement the importance of changing your thought, not just recording them.
+
+If you don't like it, you can change it in the settings.`}
+        />
       </View>
     );
   }

--- a/src/CBTListScreen.tsx
+++ b/src/CBTListScreen.tsx
@@ -9,15 +9,7 @@ import {
 } from "react-native";
 import PropTypes from "prop-types";
 import { getExercises, deleteExercise } from "./store";
-import {
-  Header,
-  SubHeader,
-  Row,
-  Container,
-  IconButton,
-  Label,
-  Paragraph,
-} from "./ui";
+import { Header, Row, Container, IconButton, Label } from "./ui";
 import theme from "./theme";
 import { CBT_FORM_SCREEN } from "./screens";
 import { SavedThought, ThoughtGroup, groupThoughtsByDay } from "./thoughts";
@@ -29,7 +21,8 @@ import {
 import universalHaptic from "./haptic";
 import { Haptic, Constants } from "expo";
 import { validThoughtGroup } from "./sanitize";
-import Alert from "./alert";
+import Alerter from "./alerter";
+import alerts from "./alerts";
 
 const ThoughtItem = ({ thought, onPress, onDelete }) => (
   <Row marginBottom={18}>
@@ -230,14 +223,7 @@ class CBTListScreen extends React.Component<Props, State> {
             />
           </Container>
         </ScrollView>
-        <Alert
-          title={"👋 Hey-o!"}
-          body={`Something's changed!
-
-Thoughts shown here are now the alternative thought, not your initial thought. We changed this to cement the importance of changing your thought, not just recording them.
-
-If you don't like it, you can change it in the settings.`}
-        />
+        <Alerter alerts={alerts} />
       </View>
     );
   }

--- a/src/CBTListScreen.tsx
+++ b/src/CBTListScreen.tsx
@@ -9,7 +9,15 @@ import {
 } from "react-native";
 import PropTypes from "prop-types";
 import { getExercises, deleteExercise } from "./store";
-import { Header, Row, Container, IconButton, Label } from "./ui";
+import {
+  Header,
+  SubHeader,
+  Row,
+  Container,
+  IconButton,
+  Label,
+  Paragraph,
+} from "./ui";
 import theme from "./theme";
 import { CBT_FORM_SCREEN } from "./screens";
 import { SavedThought, ThoughtGroup, groupThoughtsByDay } from "./thoughts";
@@ -21,6 +29,7 @@ import {
 import universalHaptic from "./haptic";
 import { Haptic, Constants } from "expo";
 import { validThoughtGroup } from "./sanitize";
+import Alert from "./alert";
 
 const ThoughtItem = ({ thought, onPress, onDelete }) => (
   <Row marginBottom={18}>
@@ -136,9 +145,7 @@ class CBTListScreen extends React.Component<Props, State> {
 
   constructor(props) {
     super(props);
-    this.state = {
-      groups: [],
-    };
+    this.state = { groups: [] };
   }
 
   syncExercises = (): void => {
@@ -170,6 +177,9 @@ class CBTListScreen extends React.Component<Props, State> {
 
   componentDidMount = () => {
     this.syncExercises();
+    setTimeout(() => {
+      this.setState({ showPopup: true });
+    }, 100);
   };
 
   navigateToForm = () => {
@@ -220,6 +230,7 @@ class CBTListScreen extends React.Component<Props, State> {
             />
           </Container>
         </ScrollView>
+        <Alert title={"Hey-o!"} body={"We changed some stuff!"} />
       </View>
     );
   }

--- a/src/alert.tsx
+++ b/src/alert.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import theme from "./theme";
+import { SubHeader, Paragraph } from "./ui";
+import posed from "react-native-pose";
+import { TouchableWithoutFeedback } from "react-native";
+
+const PopsUp = posed.View({
+  full: { height: 512 },
+  peak: { height: 128 },
+  hidden: { height: 0 },
+});
+
+interface AlertProps {
+  title: string;
+  body: string;
+}
+
+class Alert extends React.Component<AlertProps> {
+  state = {
+    view: "hidden",
+  };
+
+  componentDidMount() {
+    setTimeout(() => {
+      this.setState({ view: "peak" });
+    }, 100);
+  }
+
+  render() {
+    const { title, body } = this.props;
+
+    return (
+      <TouchableWithoutFeedback
+        onPress={() => {
+          this.setState({ view: "full" });
+        }}
+      >
+        <PopsUp
+          pose={this.state.view}
+          style={{
+            position: "absolute",
+            width: "100%",
+            height: 256,
+            padding: 24,
+            bottom: 24,
+            borderRadius: 13,
+            backgroundColor: "white",
+            borderColor: theme.lightGray,
+            borderWidth: 2,
+            shadowColor: theme.lightGray,
+            shadowOffset: { width: 0, height: 1 },
+            shadowRadius: 10,
+            shadowOpacity: 0.8,
+          }}
+        >
+          <SubHeader>{title}</SubHeader>
+          <Paragraph>{body}</Paragraph>
+        </PopsUp>
+      </TouchableWithoutFeedback>
+    );
+  }
+}
+
+export default Alert;

--- a/src/alert.tsx
+++ b/src/alert.tsx
@@ -1,13 +1,20 @@
 import React from "react";
 import theme from "./theme";
-import { SubHeader, Paragraph } from "./ui";
+import { SubHeader, Paragraph, RoundedButton } from "./ui";
 import posed from "react-native-pose";
-import { TouchableWithoutFeedback } from "react-native";
+import { TouchableWithoutFeedback, View } from "react-native";
+import universalHaptic from "./haptic";
+import { Haptic } from "expo";
 
 const PopsUp = posed.View({
-  full: { height: 512 },
-  peak: { height: 128 },
-  hidden: { height: 0 },
+  full: { height: 412, paddingTop: 18, paddingBottom: 18 },
+  peak: {
+    height: 156,
+    paddingTop: 18,
+    paddingBottom: 18,
+    transition: { type: "spring", stiffness: 150 },
+  },
+  hidden: { height: 0, paddingTop: 0, paddingBottom: 0 },
 });
 
 interface AlertProps {
@@ -23,7 +30,8 @@ class Alert extends React.Component<AlertProps> {
   componentDidMount() {
     setTimeout(() => {
       this.setState({ view: "peak" });
-    }, 100);
+      universalHaptic.notification(Haptic.NotificationFeedbackType.Success);
+    }, 350);
   }
 
   render() {
@@ -41,7 +49,7 @@ class Alert extends React.Component<AlertProps> {
             position: "absolute",
             width: "100%",
             height: 256,
-            padding: 24,
+            padding: 18,
             bottom: 24,
             borderRadius: 13,
             backgroundColor: "white",
@@ -51,10 +59,50 @@ class Alert extends React.Component<AlertProps> {
             shadowOffset: { width: 0, height: 1 },
             shadowRadius: 10,
             shadowOpacity: 0.8,
+            opacity: 1,
           }}
         >
-          <SubHeader>{title}</SubHeader>
+          <View
+            style={{
+              display: "flex",
+              flexDirection: "row",
+              justifyContent: "space-between",
+              marginBottom: 18,
+            }}
+          >
+            <SubHeader
+              style={{
+                height: 48,
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "flex-end",
+                lineHeight: 48,
+                marginBottom: 0,
+                fontSize: 24,
+              }}
+            >
+              {title}
+            </SubHeader>
+          </View>
           <Paragraph>{body}</Paragraph>
+
+          <View
+            style={{
+              padding: 24,
+              display: "flex",
+              flexDirection: "row",
+              justifyContent: "flex-end",
+            }}
+          >
+            <RoundedButton
+              title={"Got it."}
+              onPress={() => {
+                this.setState({
+                  view: "hidden",
+                });
+              }}
+            />
+          </View>
         </PopsUp>
       </TouchableWithoutFeedback>
     );

--- a/src/alerter/alertstore.ts
+++ b/src/alerter/alertstore.ts
@@ -1,0 +1,27 @@
+import { AsyncStorage } from "react-native";
+import stringify from "json-stringify-safe";
+
+const KEY = `@AlertStore:hidden`;
+
+export async function hiddenAlerts(): Promise<string[]> {
+  try {
+    const value = await AsyncStorage.getItem(KEY);
+    return value ? JSON.parse(value) : []; // empty is fine and not an error
+  } catch (err) {
+    console.error(err);
+    return [];
+  }
+}
+
+export async function hide(slug: string): Promise<boolean> {
+  try {
+    const current = await hiddenAlerts();
+    current.push(slug);
+
+    await AsyncStorage.setItem(KEY, stringify(current));
+    return true;
+  } catch (err) {
+    console.error(err);
+    return false;
+  }
+}

--- a/src/alerter/alertstore.ts
+++ b/src/alerter/alertstore.ts
@@ -1,11 +1,12 @@
 import { AsyncStorage } from "react-native";
 import stringify from "json-stringify-safe";
 
-const KEY = `@AlertStore:hidden`;
+const HIDDEN_KEY = `@AlertStore:hidden`;
+const NEW_USER_KEY = `@AlertStore:new-user`;
 
 export async function hiddenAlerts(): Promise<string[]> {
   try {
-    const value = await AsyncStorage.getItem(KEY);
+    const value = await AsyncStorage.getItem(HIDDEN_KEY);
     return value ? JSON.parse(value) : []; // empty is fine and not an error
   } catch (err) {
     console.error(err);
@@ -18,7 +19,37 @@ export async function hide(slug: string): Promise<boolean> {
     const current = await hiddenAlerts();
     current.push(slug);
 
-    await AsyncStorage.setItem(KEY, stringify(current));
+    await AsyncStorage.setItem(HIDDEN_KEY, stringify(current));
+    return true;
+  } catch (err) {
+    console.error(err);
+    return false;
+  }
+}
+
+export async function hideMultipleAlerts(slugs: string[]): Promise<boolean> {
+  try {
+    const current = await hiddenAlerts();
+    current.push(...slugs);
+
+    await AsyncStorage.setItem(HIDDEN_KEY, stringify(current));
+    return true;
+  } catch (err) {
+    console.error(err);
+    return false;
+  }
+}
+
+// Checks if someone is a new user
+// If this function has ever been called before, they're not a new user
+export async function isNewUser(): Promise<boolean> {
+  try {
+    const value = await AsyncStorage.getItem(NEW_USER_KEY);
+    if (!!value) {
+      return false;
+    }
+
+    await AsyncStorage.setItem(NEW_USER_KEY, "false");
     return true;
   } catch (err) {
     console.error(err);

--- a/src/alerter/index.tsx
+++ b/src/alerter/index.tsx
@@ -5,7 +5,12 @@ import posed from "react-native-pose";
 import { TouchableWithoutFeedback, View } from "react-native";
 import universalHaptic from "../haptic";
 import { Haptic } from "expo";
-import { hiddenAlerts, hide } from "./alertstore";
+import {
+  hiddenAlerts,
+  hide,
+  hideMultipleAlerts,
+  isNewUser,
+} from "./alertstore";
 import { sortBy } from "lodash";
 
 const PopsUp = posed.View({
@@ -137,9 +142,17 @@ class Alerter extends React.Component<AlerterProps, AlerterState> {
   }
 
   async componentDidMount() {
-    const hidden = await hiddenAlerts();
+    const { alerts } = this.props;
 
-    const showableAlerts = sortBy(this.props.alerts, ["priority"]).filter(
+    // If someone is a new user, just go ahead and hide
+    // all anouncements. They can just see the app as it is
+    if (await isNewUser()) {
+      await hideMultipleAlerts(alerts.map(({ slug }) => slug));
+      return;
+    }
+
+    const hidden = await hiddenAlerts();
+    const showableAlerts = sortBy(alerts, ["priority"]).filter(
       ({ slug }) => !hidden.includes(slug)
     );
 

--- a/src/alerter/index.tsx
+++ b/src/alerter/index.tsx
@@ -9,7 +9,7 @@ import { hiddenAlerts, hide } from "./alertstore";
 import { sortBy } from "lodash";
 
 const PopsUp = posed.View({
-  full: { height: 412, paddingTop: 18, paddingBottom: 18 },
+  full: { height: 380, paddingTop: 18, paddingBottom: 18 },
   peak: {
     height: 156,
     paddingTop: 18,
@@ -52,7 +52,7 @@ class AlertView extends React.Component<AlertViewProps> {
             position: "absolute",
             width: "100%",
             height: 256,
-            padding: 18,
+            padding: 24,
             bottom: 24,
             borderRadius: 13,
             backgroundColor: "white",

--- a/src/alerts.ts
+++ b/src/alerts.ts
@@ -1,0 +1,16 @@
+import { Alert } from "./alerter";
+
+const alerts: Alert[] = [
+  {
+    slug: "alternative-thought-title",
+    priority: 0,
+    title: "👋 Hey-o!",
+    body: `Something's changed!
+
+Thoughts shown here are now the alternative thought, not your initial thought. We changed this to cement the importance of changing your thought, not just recording them.
+
+If you don't like it, you can change it in the settings.`,
+  },
+];
+
+export default alerts;

--- a/src/screens.ts
+++ b/src/screens.ts
@@ -2,3 +2,4 @@ export const CBT_FORM_SCREEN = "CBTFormScreen";
 export const CBT_LIST_SCREEN = "CBTListScreen";
 export const CBT_ON_BOARDING_SCREEN = "CBT_ON_BOARDING_SCREEN";
 export const EXPLANATION_SCREEN = "EXPLANATION_SCREEN";
+export const SETTING_SCREEN = "SETTING_SCREEN";

--- a/src/setting/index.tsx
+++ b/src/setting/index.tsx
@@ -17,13 +17,34 @@ import {
   NavigationAction,
 } from "react-navigation";
 import { CBT_FORM_SCREEN } from "../screens";
-import * as store from "./settingstore";
+import { setSetting, getSettingOrSetDefault } from "./settingstore";
 import {
   HISTORY_BUTTON_LABEL_KEY,
   HISTORY_BUTTON_LABEL_DEFAULT,
   HistoryButtonLabelSetting,
   isHistoryButtonLabelSetting,
 } from "./settings";
+
+export { HistoryButtonLabelSetting };
+
+// Exportable settings
+export async function getHistoryButtonLabel(): Promise<
+  HistoryButtonLabelSetting
+> {
+  const value = await getSettingOrSetDefault(
+    HISTORY_BUTTON_LABEL_KEY,
+    HISTORY_BUTTON_LABEL_DEFAULT
+  );
+
+  if (!isHistoryButtonLabelSetting(value)) {
+    console.error(
+      `Something went wrong getting ${HISTORY_BUTTON_LABEL_KEY}. Got: "${value}"`
+    );
+    return HISTORY_BUTTON_LABEL_DEFAULT;
+  }
+
+  return value;
+}
 
 interface Props {
   navigation: NavigationScreenProp<NavigationState, NavigationAction>;
@@ -51,17 +72,7 @@ class SettingScreen extends React.Component<Props, State> {
   }
 
   refresh = async () => {
-    const historyButtonLabel = await store.getSettingOrSetDefault(
-      HISTORY_BUTTON_LABEL_KEY,
-      HISTORY_BUTTON_LABEL_DEFAULT
-    );
-    if (!isHistoryButtonLabelSetting(historyButtonLabel)) {
-      console.error(
-        `Something went wrong getting ${HISTORY_BUTTON_LABEL_KEY}. Got: "${historyButtonLabel}"`
-      );
-      return;
-    }
-
+    const historyButtonLabel = await getHistoryButtonLabel();
     this.setState({
       historyButtonLabel,
       ready: true,
@@ -81,13 +92,13 @@ class SettingScreen extends React.Component<Props, State> {
     }
 
     if (this.state.historyButtonLabel === "alternative-thought") {
-      store.setSetting<HistoryButtonLabelSetting>(
+      setSetting<HistoryButtonLabelSetting>(
         HISTORY_BUTTON_LABEL_KEY,
         "automatic-thought"
       );
       this.refresh();
     } else {
-      store.setSetting<HistoryButtonLabelSetting>(
+      setSetting<HistoryButtonLabelSetting>(
         HISTORY_BUTTON_LABEL_KEY,
         "alternative-thought"
       );

--- a/src/setting/index.tsx
+++ b/src/setting/index.tsx
@@ -1,0 +1,159 @@
+import React from "react";
+import { ScrollView, View, StatusBar } from "react-native";
+import theme from "../theme";
+import { Constants } from "expo";
+import {
+  Header,
+  Row,
+  Container,
+  IconButton,
+  SubHeader,
+  Paragraph,
+  RoundedSelectorButton,
+} from "../ui";
+import {
+  NavigationScreenProp,
+  NavigationState,
+  NavigationAction,
+} from "react-navigation";
+import { CBT_FORM_SCREEN } from "../screens";
+import * as store from "./settingstore";
+import {
+  HISTORY_BUTTON_LABEL_KEY,
+  HISTORY_BUTTON_LABEL_DEFAULT,
+  HistoryButtonLabelSetting,
+  isHistoryButtonLabelSetting,
+} from "./settings";
+
+interface Props {
+  navigation: NavigationScreenProp<NavigationState, NavigationAction>;
+}
+
+interface State {
+  ready: boolean;
+  historyButtonLabel?: HistoryButtonLabelSetting;
+}
+
+class SettingScreen extends React.Component<Props, State> {
+  static navigationOptions = {
+    header: null,
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      ready: false,
+    };
+  }
+
+  async componentDidMount() {
+    await this.refresh();
+  }
+
+  refresh = async () => {
+    const historyButtonLabel = await store.getSettingOrSetDefault(
+      HISTORY_BUTTON_LABEL_KEY,
+      HISTORY_BUTTON_LABEL_DEFAULT
+    );
+    if (!isHistoryButtonLabelSetting(historyButtonLabel)) {
+      console.error(
+        `Something went wrong getting ${HISTORY_BUTTON_LABEL_KEY}. Got: "${historyButtonLabel}"`
+      );
+      return;
+    }
+
+    this.setState({
+      historyButtonLabel,
+      ready: true,
+    });
+  };
+
+  navigateToForm = () => {
+    this.props.navigation.navigate(CBT_FORM_SCREEN, {
+      thought: false,
+    });
+  };
+
+  toggleHistoryButtonLabels = () => {
+    if (!this.state.ready) {
+      this.refresh();
+      return;
+    }
+
+    if (this.state.historyButtonLabel === "alternative-thought") {
+      store.setSetting<HistoryButtonLabelSetting>(
+        HISTORY_BUTTON_LABEL_KEY,
+        "automatic-thought"
+      );
+      this.refresh();
+    } else {
+      store.setSetting<HistoryButtonLabelSetting>(
+        HISTORY_BUTTON_LABEL_KEY,
+        "alternative-thought"
+      );
+      this.refresh();
+    }
+  };
+
+  render() {
+    const { historyButtonLabel, ready } = this.state;
+
+    if (!ready) {
+      return <View style={{ backgroundColor: theme.lightOffwhite }} />;
+    }
+
+    return (
+      <View style={{ backgroundColor: theme.lightOffwhite }}>
+        <ScrollView
+          style={{
+            backgroundColor: theme.lightOffwhite,
+            marginTop: Constants.statusBarHeight,
+            paddingTop: 24,
+            height: "100%",
+          }}
+        >
+          <Container>
+            <StatusBar barStyle="dark-content" />
+            <Row style={{ marginBottom: 18 }}>
+              <Header>quirk*</Header>
+              <IconButton
+                featherIconName={"edit"}
+                onPress={() => this.navigateToForm()}
+              />
+            </Row>
+
+            <Row
+              style={{
+                marginBottom: 18,
+                display: "flex",
+                flexDirection: "column",
+              }}
+            >
+              <SubHeader>*history button labels</SubHeader>
+              <Paragraph
+                style={{
+                  marginBottom: 9,
+                }}
+              >
+                By default, we set the buttons in the history screen to use the
+                Alternative Thought. This helps cement the thought as "changed."
+              </Paragraph>
+              <RoundedSelectorButton
+                title={"Alternative Thought"}
+                selected={historyButtonLabel === "alternative-thought"}
+                onPress={() => this.toggleHistoryButtonLabels()}
+              />
+              <RoundedSelectorButton
+                title={"Automatic Thought"}
+                selected={historyButtonLabel === "automatic-thought"}
+                onPress={() => this.toggleHistoryButtonLabels()}
+              />
+            </Row>
+          </Container>
+        </ScrollView>
+      </View>
+    );
+  }
+}
+
+export default SettingScreen;

--- a/src/setting/index.tsx
+++ b/src/setting/index.tsx
@@ -16,7 +16,7 @@ import {
   NavigationState,
   NavigationAction,
 } from "react-navigation";
-import { CBT_FORM_SCREEN } from "../screens";
+import { CBT_LIST_SCREEN } from "../screens";
 import { setSetting, getSettingOrSetDefault } from "./settingstore";
 import {
   HISTORY_BUTTON_LABEL_KEY,
@@ -79,10 +79,8 @@ class SettingScreen extends React.Component<Props, State> {
     });
   };
 
-  navigateToForm = () => {
-    this.props.navigation.navigate(CBT_FORM_SCREEN, {
-      thought: false,
-    });
+  navigateToList = () => {
+    this.props.navigation.navigate(CBT_LIST_SCREEN);
   };
 
   toggleHistoryButtonLabels = () => {
@@ -128,8 +126,8 @@ class SettingScreen extends React.Component<Props, State> {
             <Row style={{ marginBottom: 18 }}>
               <Header>quirk*</Header>
               <IconButton
-                featherIconName={"edit"}
-                onPress={() => this.navigateToForm()}
+                featherIconName={"list"}
+                onPress={() => this.navigateToList()}
               />
             </Row>
 

--- a/src/setting/settings.ts
+++ b/src/setting/settings.ts
@@ -1,0 +1,11 @@
+export const HISTORY_BUTTON_LABEL_KEY = "history-button-labels";
+export type HistoryButtonLabelSetting =
+  | "alternative-thought"
+  | "automatic-thought";
+export function isHistoryButtonLabelSetting(
+  arg: string
+): arg is HistoryButtonLabelSetting {
+  return arg === "alternative-thought" || arg === "automatic-thought";
+}
+export const HISTORY_BUTTON_LABEL_DEFAULT: HistoryButtonLabelSetting =
+  "alternative-thought";

--- a/src/setting/settingstore.ts
+++ b/src/setting/settingstore.ts
@@ -1,0 +1,41 @@
+import { AsyncStorage } from "react-native";
+
+const PREFIX = `@SettingsStore:`;
+
+function getKey(slug: string) {
+  return PREFIX + slug;
+}
+
+export async function getSettingOrSetDefault(
+  slug: string,
+  defaultValue: string
+): Promise<string> {
+  try {
+    const result = await AsyncStorage.getItem(getKey(slug));
+
+    if (!result || result.length === 0) {
+      // We don't use the wrapped version of setSetting here
+      // so we correctly attribute the error
+      await AsyncStorage.setItem(getKey(slug), defaultValue);
+      return await AsyncStorage.getItem(getKey(slug));
+    }
+
+    return result;
+  } catch (err) {
+    console.error(err);
+    return "";
+  }
+}
+
+export async function setSetting<T extends string>(
+  slug: string,
+  value: T
+): Promise<boolean> {
+  try {
+    await AsyncStorage.setItem(getKey(slug), value);
+    return true;
+  } catch (err) {
+    console.error(err);
+    return false;
+  }
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -4,9 +4,10 @@ import uuidv4 from "uuid/v4";
 import { Thought, SavedThought } from "./thoughts";
 
 const EXISTING_USER_KEY = "@Quirk:existing-user";
+const THOUGHTS_KEY_PREFIX = `@Quirk:thoughts:`;
 
 export function getThoughtKey(info): string {
-  return `@Quirk:thoughts:${info}`;
+  return THOUGHTS_KEY_PREFIX + info;
 }
 
 export async function exists(key: string): Promise<boolean> {
@@ -82,7 +83,10 @@ export const deleteExercise = async (uuid: string) => {
 
 export const getExercises = async () => {
   try {
-    const keys = await AsyncStorage.getAllKeys();
+    const keys = (await AsyncStorage.getAllKeys()).filter(key =>
+      key.startsWith(THOUGHTS_KEY_PREFIX)
+    );
+
     let rows = await AsyncStorage.multiGet(keys);
 
     // It's better to lose data than to brick the app

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -263,7 +263,15 @@ RoundedButton.defaultProps = {
   width: 100,
 };
 
-export const IconButton = ({ featherIconName, onPress, ...style }) => (
+export const IconButton = ({
+  featherIconName,
+  onPress,
+  style,
+}: {
+  featherIconName: string;
+  onPress: () => void;
+  style?: object;
+}) => (
   <TouchableOpacity
     style={{
       backgroundColor: theme.lightGray,

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -182,6 +182,13 @@ export const RoundedButton = ({
   textColor,
   width,
   disabled,
+}: {
+  title: string;
+  onPress: () => void;
+  fillColor?: string;
+  textColor?: string;
+  width?: number;
+  disabled?: boolean;
 }) => (
   <TouchableOpacity
     style={{
@@ -206,15 +213,6 @@ export const RoundedButton = ({
     </Text>
   </TouchableOpacity>
 );
-
-RoundedButton.propTypes = {
-  title: PropTypes.string.isRequired,
-  onPress: PropTypes.func.isRequired,
-  fillColor: PropTypes.string,
-  textColor: PropTypes.string,
-  width: PropTypes.number,
-  disabled: PropTypes.bool,
-};
 
 RoundedButton.defaultProps = {
   fillColor: theme.blue,

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -21,7 +21,7 @@ export interface Component {
   style?: object;
 }
 
-export const Row = ({ children, ...style }) => (
+export const Row = ({ children, style }: { children: any; style?: any }) => (
   <View
     style={{
       flexDirection: "row",
@@ -174,6 +174,49 @@ RoundedSelector.propTypes = {
   onPress: PropTypes.func.isRequired,
   style: PropTypes.object,
 };
+
+export const RoundedSelectorButton = ({
+  title,
+  selected = false,
+  onPress,
+}: {
+  title: string;
+  selected?: boolean;
+  onPress: () => void;
+}) => (
+  <TouchableOpacity
+    onPress={onPress}
+    style={{
+      backgroundColor: selected ? theme.blue : "white",
+      borderColor: selected ? theme.darkBlue : theme.lightGray,
+      borderBottomWidth: 2,
+      paddingTop: 8,
+      paddingBottom: 8,
+      paddingRight: 12,
+      borderRadius: 8,
+      borderWidth: 1,
+      marginBottom: 4,
+      marginTop: 1,
+      flexDirection: "row",
+      justifyContent: "space-between",
+    }}
+  >
+    <View style={{ flexDirection: "row" }}>
+      <Text
+        style={{
+          fontWeight: "400",
+          fontSize: 16,
+          color: selected ? "white" : theme.darkText,
+          marginLeft: 12,
+        }}
+      >
+        {title}
+      </Text>
+    </View>
+
+    {selected && <Feather name={"check"} size={16} color={"white"} />}
+  </TouchableOpacity>
+);
 
 export const RoundedButton = ({
   title,

--- a/yarn.lock
+++ b/yarn.lock
@@ -570,6 +570,11 @@
     pouchdb-collections "^1.0.1"
     tiny-queue "^0.2.1"
 
+"@popmotion/easing@^1.0.1":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@popmotion/easing/-/easing-1.0.2.tgz#17d925c45b4bf44189e5a38038d149df42d8c0b4"
+  integrity sha512-IkdW0TNmRnWTeWI7aGQIVDbKXPWHVEYdGgd5ZR4SH/Ty/61p63jCjrPxX1XrR7IGkl08bjhJROStD7j+RKgoIw==
+
 "@react-navigation/core@3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-3.0.2.tgz#8631801533a27d034a3b8421dfd0510a9f27dcf3"
@@ -628,6 +633,11 @@
 "@types/lodash@*":
   version "4.14.119"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.119.tgz#be847e5f4bc3e35e46d041c394ead8b603ad8b39"
+
+"@types/node@^10.0.5":
+  version "10.14.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.4.tgz#1c586b991457cbb58fef51bc4e0cfcfa347714b5"
+  integrity sha512-DT25xX/YgyPKiHFOpNuANIQIVvYEwCWXgK2jYYwqgaMrYE6+tq+DtmMwlD3drl6DJbUwtlIDnn0d7tIn/EbXBg==
 
 "@types/prop-types@*":
   version "15.5.8"
@@ -719,6 +729,15 @@ ajv@^6.5.5:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
+
+animated-pose@^1.0.0, animated-pose@^1.2.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/animated-pose/-/animated-pose-1.2.3.tgz#3a2f47e0e5711edfdeaceb18bc9afc448cf4d401"
+  integrity sha512-7XtulKltEIt/E+7jOz4+pCduZENRI3DU/8zvqzCGmKTAmPJiXeT34P4oYmZ83PzKd4orJqv0kN3D7Zh0COjPWg==
+  dependencies:
+    "@popmotion/easing" "^1.0.1"
+    hey-listen "^1.0.5"
+    pose-core "^2.0.3"
 
 ansi-colors@^1.0.1:
   version "1.1.0"
@@ -2876,6 +2895,11 @@ has@^1.0.1, has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hey-listen@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/hey-listen/-/hey-listen-1.0.5.tgz#6d0a3a2f60177f65bc4404d571a00025bf5dc20e"
+  integrity sha512-O2iCNxBBGb4hOxL9tUdnoPwDYmZhQ29t5xKV74BVZNdvwCDXCpVYTJ4yoaibc1V0I8Yw3K3nwmvDpoyjnCqUaw==
+
 hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
@@ -4718,6 +4742,16 @@ pn@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
 
+pose-core@^2.0.3:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/pose-core/-/pose-core-2.1.0.tgz#653c85a9a06f924611b909b4a2180ce102bbb258"
+  integrity sha512-36mVAnIgbM6jfyRug8EqqFbazHUAk9dxwVRpX61FlVw3amI/j7AFegtVU56N0Dht2aYDJIhgYPUYraT1CzjHDw==
+  dependencies:
+    "@types/invariant" "^2.2.29"
+    "@types/node" "^10.0.5"
+    hey-listen "^1.0.5"
+    tslib "^1.9.1"
+
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
@@ -4903,6 +4937,14 @@ react-native-maps@*, react-native-maps@expo/react-native-maps#v0.22.1-exp.0:
   version "0.22.1"
   resolved "https://codeload.github.com/expo/react-native-maps/tar.gz/e6f98ff7272e5d0a7fe974a41f28593af2d77bb2"
 
+react-native-pose@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/react-native-pose/-/react-native-pose-0.9.0.tgz#890be7da8853c89e22ee078922375ab8a04590c4"
+  integrity sha512-zpWf/p44W7+oJD1+Ku9wb21DCtTSmuBfLut6GBi/L3Ik1kYrEgC91Yg211/jqnhpp5PaI+kqP/GvBqhPJgtKFQ==
+  dependencies:
+    animated-pose "^1.2.0"
+    react-pose-core "^0.5.0"
+
 react-native-reanimated@1.0.0-alpha.10:
   version "1.0.0-alpha.10"
   resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-1.0.0-alpha.10.tgz#e9e6fb35a2cf52fdc912b9fbc76f34f80698e530"
@@ -5054,6 +5096,14 @@ react-navigation@^3.0.8:
     react-navigation-drawer "1.0.5"
     react-navigation-stack "1.0.5"
     react-navigation-tabs "1.0.1"
+
+react-pose-core@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/react-pose-core/-/react-pose-core-0.5.0.tgz#1f362cae5eb6331f430cde75c662879017681da3"
+  integrity sha512-vzpeO0G47gDBxTQ2DZMKIbbz3BdEPT6dr3LoaxyZQWaPMBqYNY2hdi0cRLqqy5EWmvqorLY/vl/q3arNGBmUeg==
+  dependencies:
+    animated-pose "^1.0.0"
+    hey-listen "^1.0.5"
 
 react-proxy@^1.1.7:
   version "1.1.8"
@@ -5848,7 +5898,7 @@ ts-jest@^23.10.5:
     semver "^5.5"
     yargs-parser "10.x"
 
-tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.3:
+tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.1, tslib@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
 


### PR DESCRIPTION
# Overview

Changes the button on the list screen to be the alternative thought. 

To do this without messing anyone up, I'm adding the ability to revert back via settings. But to get people's attention, I'm also adding an alert system that let's folks know that this change is here. 