### PR TITLE
add ipad build and fix orientation

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,7 +6,7 @@
     "sdkVersion": "31.0.0",
     "platforms": ["ios", "android"],
     "version": "1.6.0",
-    "orientation": "portrait",
+    "orientation": "all",
     "githubUrl": "https://github.com/Flaque/quirk",
     "primaryColor": "#F8A5C2",
     "splash": {
@@ -16,7 +16,7 @@
     },
     "assetBundlePatterns": ["**/*"],
     "ios": {
-      "supportsTablet": false,
+      "supportsTablet": true,
       "bundleIdentifier": "tech.econn.quirk",
       "icon": "./assets/ios.png"
     },


### PR DESCRIPTION
this is a first  I do not have an xcode env.

you may have to follow this:

https://stackoverflow.com/questions/43899020/how-do-i-build-a-react-native-app-so-that-it-runs-as-an-ipad-app-on-an-ipad