### PR TITLE
Refactored usage of navigator.navigate() to navigator.push()

### DIFF
--- a/src/CBTFormScreen.tsx
+++ b/src/CBTFormScreen.tsx
@@ -22,7 +22,7 @@ import universalHaptic from "./haptic";
 import { AppLoading, Haptic, Constants } from "expo";
 import CBTView from "./CBTView";
 import CBTOnBoardingScreen from "./CBTOnBoardingScreen";
-import i18n from './i18n';
+import i18n from "./i18n";
 
 const CBTViewer = ({ thought, onEdit, onNew }) => {
   if (!thought.uuid) {
@@ -41,11 +41,15 @@ const CBTViewer = ({ thought, onEdit, onNew }) => {
         <RoundedButton
           fillColor="transparent"
           textColor={theme.blue}
-          title={i18n.t('cbt_form.edit')}
+          title={i18n.t("cbt_form.edit")}
           onPress={() => onEdit(thought.uuid)}
           disabled={false}
         />
-        <RoundedButton title={i18n.t('cbt_form.new')} onPress={onNew} disabled={false} />
+        <RoundedButton
+          title={i18n.t("cbt_form.new")}
+          onPress={onNew}
+          disabled={false}
+        />
       </Row>
     </View>
   );
@@ -187,14 +191,12 @@ export default class CBTFormScreen extends React.Component<Props, State> {
             <Row>
               <IconButton
                 featherIconName={"help-circle"}
-                onPress={() =>
-                  this.props.navigation.navigate(EXPLANATION_SCREEN)
-                }
+                onPress={() => this.props.navigation.push(EXPLANATION_SCREEN)}
               />
               <Header>quirk</Header>
               <IconButton
                 featherIconName={"list"}
-                onPress={() => this.props.navigation.navigate(CBT_LIST_SCREEN)}
+                onPress={() => this.props.navigation.push(CBT_LIST_SCREEN)}
               />
             </Row>
 

--- a/src/CBTListScreen.tsx
+++ b/src/CBTListScreen.tsx
@@ -200,7 +200,7 @@ class CBTListScreen extends React.Component<Props, State> {
   };
 
   navigateToSettings = () => {
-    this.props.navigation.navigate(SETTING_SCREEN);
+    this.props.navigation.push(SETTING_SCREEN);
   };
 
   navigateToForm = () => {
@@ -208,7 +208,7 @@ class CBTListScreen extends React.Component<Props, State> {
   };
 
   navigateToFormWithThought = (thought: SavedThought | boolean) => {
-    this.props.navigation.navigate(CBT_FORM_SCREEN, {
+    this.props.navigation.push(CBT_FORM_SCREEN, {
       thought,
     });
   };

--- a/src/ExplanationScreen.tsx
+++ b/src/ExplanationScreen.tsx
@@ -269,7 +269,7 @@ class ExplanationScreen extends React.Component<Props> {
             <Header>quirk.</Header>
             <IconButton
               featherIconName={"edit"}
-              onPress={() => this.props.navigation.navigate(CBT_FORM_SCREEN)}
+              onPress={() => this.props.navigation.push(CBT_FORM_SCREEN)}
             />
           </View>
 

--- a/src/setting/index.tsx
+++ b/src/setting/index.tsx
@@ -80,7 +80,7 @@ class SettingScreen extends React.Component<Props, State> {
   };
 
   navigateToList = () => {
-    this.props.navigation.navigate(CBT_LIST_SCREEN);
+    this.props.navigation.push(CBT_LIST_SCREEN);
   };
 
   toggleHistoryButtonLabels = () => {


### PR DESCRIPTION
Resolves the weird "back to previous screen" behavior #17

The problem was that the previous function call `navigator.navigate()` clears the stack before pushing a new frame. One should use `navigator.push()` to always make sure the previous frame was not discarded.

Note: May have unexpected behavior on ios. I recommend using a ternary statement to resolve this would-be-issue.