### PR TITLE
Announcing: The Open Quirk Project

### DIFF
--- a/src/CBTFormScreen.tsx
+++ b/src/CBTFormScreen.tsx
@@ -19,6 +19,7 @@ import CBTView from "./CBTView";
 import { CBTOnBoardingComponent } from "./CBTOnBoarding";
 import i18n from "./i18n";
 import { setIsExistingUser } from "./store";
+import { recordScreenCallOnFocus } from "./navigation";
 
 const CBTViewer = ({ thought, onEdit, onNew }) => {
   if (!thought.uuid) {
@@ -97,6 +98,8 @@ export default class CBTFormScreen extends React.Component<Props, State> {
         }
       }
     });
+
+    recordScreenCallOnFocus(this.props.navigation, "form");
 
     getIsExistingUser().then(isExisting => {
       this.setState({ shouldShowOnBoarding: !isExisting, isLoading: false });

--- a/src/CBTListScreen.tsx
+++ b/src/CBTListScreen.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import {
-  Text,
   TouchableOpacity,
   ScrollView,
   StatusBar,
@@ -26,6 +25,7 @@ import { HistoryButtonLabelSetting, getHistoryButtonLabel } from "./setting";
 import i18n from "./i18n";
 import { emojiForSlug } from "./distortions";
 import { take } from "lodash";
+import { recordScreenCallOnFocus } from "./navigation";
 
 const ThoughtItem = ({
   thought,
@@ -190,6 +190,8 @@ class CBTListScreen extends React.Component<Props, State> {
     this.props.navigation.addListener("willFocus", () => {
       this.loadSettings();
     });
+
+    recordScreenCallOnFocus(this.props.navigation, "list");
   }
 
   loadExercises = (): void => {

--- a/src/CBTOnBoarding.tsx
+++ b/src/CBTOnBoarding.tsx
@@ -22,6 +22,7 @@ import {
   NavigationAction,
 } from "react-navigation";
 import { Haptic } from "expo";
+import { recordScreenCallOnFocus } from "./navigation";
 
 const thought: Thought = {
   automaticThought: i18n.t("onboarding_screen.auto_thought_ex"),
@@ -374,6 +375,12 @@ export class CBTOnBoardingScreen extends React.Component<ScreenProps> {
   static navigationOptions = {
     header: null,
   };
+
+  constructor(props) {
+    super(props);
+
+    recordScreenCallOnFocus(this.props.navigation, "intro");
+  }
 
   stopOnBoarding = () => {
     universalHaptic.notification(Haptic.NotificationFeedbackType.Success);

--- a/src/ExplanationScreen.tsx
+++ b/src/ExplanationScreen.tsx
@@ -12,6 +12,7 @@ import { CBT_ON_BOARDING_SCREEN } from "./screens";
 import i18n from "./i18n";
 
 import { BubbleThought } from "./Bubbles";
+import { recordScreenCallOnFocus } from "./navigation";
 
 interface Props {
   navigation: NavigationScreenProp<NavigationState, NavigationAction>;
@@ -199,6 +200,11 @@ class ExplanationScreen extends React.Component<Props> {
   static navigationOptions = {
     header: null,
   };
+
+  constructor(props) {
+    super(props);
+    recordScreenCallOnFocus(this.props.navigation, "help");
+  }
 
   navigateToOnboardingScreen = () => {
     this.props.navigation.navigate(CBT_ON_BOARDING_SCREEN);

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -1,0 +1,14 @@
+import * as stats from "./stats";
+import { NavigationScreenProp } from "react-navigation";
+
+/**
+ * Plug this into anything that's using screen calls
+ */
+export function recordScreenCallOnFocus(
+  navigation: NavigationScreenProp<any, any>,
+  screen: stats.ScreenType
+) {
+  navigation.addListener("didFocus", () => {
+    stats.screen(screen);
+  });
+}

--- a/src/setting/index.tsx
+++ b/src/setting/index.tsx
@@ -25,6 +25,7 @@ import {
   isHistoryButtonLabelSetting,
 } from "./settings";
 import i18n from "../i18n";
+import { recordScreenCallOnFocus } from "../navigation";
 
 export { HistoryButtonLabelSetting };
 
@@ -66,6 +67,7 @@ class SettingScreen extends React.Component<Props, State> {
     this.state = {
       ready: false,
     };
+    recordScreenCallOnFocus(this.props.navigation, "settings");
   }
 
   async componentDidMount() {

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -1,0 +1,46 @@
+/**
+ * This is Quirk's public stats file and is part of the
+ * Open-Quirk project.
+ *
+ * **What's the Open Quirk Project?**
+ * Quirk should be open; code _and_ stats. Typically,
+ * a developer gets stats through the app stores, and even
+ * if the app is open source, those stats tend to be kept
+ * private.
+ *
+ * Quirk's not gonna be like that. Instead, stats will
+ * be shared openly.
+ *
+ * That let's community members:
+ * - understand the status of the project
+ * - see the fruits of their support
+ *
+ * Plus, it allows researchers and mental health professionals
+ * access the info in order to develop better treatments.
+ *
+ * These stats are valuable data that's created by
+ * you, the user. **So you, the user, should have access to it.**
+ */
+
+import { Segment } from "expo";
+
+Segment.initialize({
+  androidWriteKey: "ZivFALGI9FH1L4WiAEY3o5PDtKwvLLxB",
+  iosWriteKey: "BpLkO0nXEQJUJyjQCqZk5TWawTQN83QC",
+});
+
+// Don't rename these; it can mess a bunch of stuff down the pipe
+export type ScreenType = "main" | "help" | "intro" | "list" | "settings";
+
+/**
+ * Screen calls bump a counter every time someone sees a particular screen.
+ *
+ * **Example Info:**
+ * If lots of users don't look at the help screen, maybe it's
+ * broken! Similarly, if people use it a _lot_ then maybe we should
+ * invest in making it better, because a single trip isn't good
+ * enough.
+ */
+export function screen(val: ScreenType) {
+  Segment.screen(val);
+}


### PR DESCRIPTION
# The Open Quirk Project

**At the moment, all stats about downloads and usage are hidden only to me**. This is pretty typical; even though it's an open source app, only the developer gets to know how many people are using it. 

With Quirk, that _won't_ be the case.

## Stats are becoming public
Public stats means any professional can do research on the effectiveness of Quirk. Public stats means contributors get to understand exactly the size and usefulness of the project. Public stats help other creators understand what it takes for something like this to succeed.

And most importantly, they're _public_. As in: it's not collecting your private info. Because this is info that will be shared publicly it _forces_ future developers to keep your privacy in mind. 

## What this PR does
In order for stats to be public, we need to move the stat collection from the OS, to the app. The app stores are pretty awful about exporting data. 

This also makes stat collection explicit to observers, rather than hiding behind "the device is doing it."

## Future Steps
Next, we'll route these stats to public charts on the website that show a 30 day rolling average of usage numbers with explanations of what the data means. (probably, there might be better way to visualize this) 

## Current Metrics
As of today, Quirk has about ~700 monthly active users and about 3,285 downloads. I would expect the number of monthly active users to dip to around ~300 and then rise since we had a pretty big spike earlier this month. 

<img width="853" alt="Screen Shot 2019-04-25 at 6 23 01 PM" src="https://user-images.githubusercontent.com/5942769/56777614-612b8a00-6787-11e9-9a88-fe7401599246.png">
  
