### PR TITLE
Fix tests

### DIFF
--- a/src/locals/zh-CN.json
+++ b/src/locals/zh-CN.json
@@ -133,5 +133,5 @@
   "should_statements": "必定要求",
   "should_statements_explanation_1": "假如你分配工作给一个没有做此项工作能力的人，你就会毁在\"必要做到\"上。举例来说，如果你有飞行恐惧症，并告诉自己\"我不应该害怕坐飞机，这飞机又没有故障！\"你承担了过重的自我心理负担。你有对飞行的恐惧，这是正常的，谁都会有害怕飞行的恐惧心态！",
   "should_statements_explanation_2": "如你大声说出来的必定语句听起来很无厘头的， 这才是问题重点！因为它们是不合逻辑！",
-  "should_statements_thought": "我是一个成年人，我肯定不会有这些心理问题。",
+  "should_statements_thought": "我是一个成年人，我肯定不会有这些心理问题。"
 }


### PR DESCRIPTION
They were failing because of an extra comma 😅

```
yarn run v1.15.2
$ jest
 FAIL  src/sanitize.test.ts
  ● Test suite failed to run

    SyntaxError: Unexpected token } in JSON at position 5224
        at JSON.parse (<anonymous>)

      10 | import fi from "./locals/fi.json";
      11 | import ru from "./locals/ru.json";
    > 12 | import zhCN from "./locals/zh-CN.json";
         | ^
      13 | import ptPT from "./locals/pt-pt.json";
      14 |
      15 | i18n.fallbacks = true;

      at Runtime._loadModule (node_modules/jest-runner/node_modules/jest-runtime/build/index.js:540:59)
      at Object.<anonymous> (src/i18n.ts:12:1)
      at Object.<anonymous> (src/distortions.ts:1:1)

 FAIL  src/thoughts.test.ts
  ● Test suite failed to run

    SyntaxError: Unexpected token } in JSON at position 5224
        at JSON.parse (<anonymous>)

      10 | import fi from "./locals/fi.json";
      11 | import ru from "./locals/ru.json";
    > 12 | import zhCN from "./locals/zh-CN.json";
         | ^
      13 | import ptPT from "./locals/pt-pt.json";
      14 |
      15 | i18n.fallbacks = true;

      at Runtime._loadModule (node_modules/jest-runner/node_modules/jest-runtime/build/index.js:540:59)
      at Object.<anonymous> (src/i18n.ts:12:1)
      at Object.<anonymous> (src/distortions.ts:1:1)

Test Suites: 2 failed, 2 total
```