### PR TITLE
Fixes for german translation

### DIFF
--- a/src/CBTOnBoarding.tsx
+++ b/src/CBTOnBoarding.tsx
@@ -197,6 +197,7 @@ const YourThoughtsArentYourThoughts = () => (
       <Exaggerated>
         {i18n.t("onboarding_screen.thoughts_arent_thoughts.emphasis1")}
       </Exaggerated>
+      {i18n.t("onboarding_screen.thoughts_arent_thoughts.line2")}
     </LeftPushedHeader>
   </Main>
 );
@@ -208,6 +209,7 @@ const YourThoughtsAreDistorted = () => (
       <Exaggerated>
         {i18n.t("onboarding_screen.your_distorted.emphasis1")}
       </Exaggerated>
+      {i18n.t("onboarding_screen.your_distorted.line2")}
     </LeftPushedHeader>
   </Main>
 );

--- a/src/locals/de.json
+++ b/src/locals/de.json
@@ -1,18 +1,18 @@
 {
   "onboarding_screen": {
     "auto_thought_ex": "Ich war nicht auf Georg's Party, er hasst mich bestimmt.",
-    "challenge_ex": "George weiß ich kann nicht jedes mal Zeit finden, Ich würde ihn nicht hassen, wenn er etwas von mir verpasst.\n\nIch sollte mich selbst mindestens so gut behandeln wie ich andere behandle.",
+    "challenge_ex": "George weiß ich kann nicht jedes mal Zeit finden. Ich würde ihn nicht hassen, wenn er etwas von mir verpasst.\n\nIch sollte mich selbst mindestens so gut behandeln wie ich andere behandle.",
     "alt_thought_ex": "Es ist wahr, ich habe George's Party verpasst, ich kann mich entschuldigen, er wird mir wahrscheinlich verzeihen.",
     "cog_distortion": { "label": "Gedanken Lesen", "slug": "mind-reading" },
     "intro": {
       "line1": "Willkommen zu",
       "emphasis1": "quirk",
       "line2": ", der",
-      "emphasis2": "kognitiven Verhaltens-therapie (CBT)",
+      "emphasis2": "Kognitiven Verhaltenstherapie (CBT)",
       "line3": "App."
     },
     "crash_course": {
-      "line1": "Dies ist ein",
+      "line1": "Dies ist eine",
       "emphasis1": "grundlegende Hilfsanwendung",
       "line2": "in CBT und",
       "emphasis2": "keine Alternative",
@@ -20,7 +20,7 @@
     },
     "mood_thoughts": {
       "line1": "Erstens:",
-      "emphasis1": "deine Gedanken beeinflußen deine Stimmung."
+      "emphasis1": "deine Gedanken beeinflussen deine Stimmung."
     },
     "thoughts_arent_thoughts": {
       "line1": "Zweitens: deine Gedanken können",
@@ -49,17 +49,17 @@
       "line2": "der angelernten Gedanken."
     },
     "bad_thought_note": {
-      "line1": "Schreiben deinen Gedanken auf:",
-      "line2": "Ich war nicht auf Georg's Party, er hasst mich bestimmt."
+      "line1": "Schreibe deinen Gedanken auf:",
+      "line2": "Ich war nicht auf Georgs Party, er hasst mich bestimmt."
     },
     "identify_distortions": {
       "line1": "Achte auf eine",
       "emphasis1": "verzerrte Wahrnehmung."
     },
     "bad_distortions": {
-      "line1": "Bist du dir sicher George hast dich? Wenn nicht, bist du am",
+      "line1": "Bist du dir sicher George hasst dich? Wenn nicht, bist du am",
       "emphasis1": "Gedanken Lesen",
-      "line2": "Ich war nicht auf Georg's Party, er hasst mich bestimmt."
+      "line2": "Ich war nicht auf Georgs Party, er hasst mich bestimmt."
     },
     "challenge_screen": {
       "line1": "3. Wieso ist dieser Gedanke nicht realistisch?",
@@ -69,7 +69,7 @@
       "line1": "Schreib stattdessen:"
     },
     "alt_thought": {
-      "line1": "4. Nun, schreib einen",
+      "line1": "4. Nun, notiere einen",
       "emphasis1": "alternativen Gedanken."
     },
     "show_off": {
@@ -91,17 +91,17 @@
     "auto_thought_placeholder": "Was geht dir durch den Kopf?",
     "cog_distortion": "verzerrte Wahrnehmung",
     "challenged": "Herausfordern",
-    "changed_placeholder": "erörtern deinen Gedanken!",
+    "changed_placeholder": "erörtere deinen Gedanken!",
     "alt_thought_placeholder": "Was könnte ich anstatt dessen denken?"
   },
   "all_or_nothing_thinking": "Alles oder Nichts Denken",
   "all_or_nothing_thinking_explanation": "Die Verzehrung passiert wenn du keinen Mittelweg siehst. Wenn du denkst, dass ein kleiner Fehler in deinem Verhalten bedeutet, dass du endgültig verdorben oder schlecht bist, denkst du wahrscheinlich in Schwarz und Weiß.",
   "all_or_nothing_thinking_thought": "Ich habe das Bewerbungsgespräch vermasselt, ich bin komplett uneinstellbar.",
   "catastrophizing": "Katastrophen ausdenken",
-  "catastrophizing_explanation": "Wenn du ein kleines Problem größer machst als es ist, denkst du dir Katastrophen aus. Hast du einen kleinen Fehler bei der Arbeit gemacht und bist fürchtest dich davor, dass es Jemand rausfindet, obwohl es nichts ernstes ist? Du denkst dir Katastrophen aus.",
+  "catastrophizing_explanation": "Wenn du ein kleines Problem größer machst als es ist, denkst du dir Katastrophen aus. Hast du einen kleinen Fehler bei der Arbeit gemacht und fürchtest dich davor, dass es Jemand rausfindet, obwohl es nichts ernstes ist? Du denkst dir Katastrophen aus.",
   "catastrophizing_thought": "Ich fühle mich hektisch, vielleicht habe ich einen Schlaganfall.",
   "emotional_reasoning": "emotionales Schlussfolgern",
-  "emotional_reasoning_explanation_1": "\"Ich fühle es, deswegen muss es wahr sein.\" Wenn du dich erwischst wie du die \"Gefahr\" von etwas dir selbst unbewusst erklärst, weil du davor Angst hast, dann tust du wahrscheinlich emotional Schlussfolgern. Es ist nicht gefährlich weil du davor Angst hast und du bist nicht furchtbar nur weil du es vielleicht denkst.",
+  "emotional_reasoning_explanation_1": "\"Ich fühle es, deswegen muss es wahr sein.\" Wenn du dich erwischst wie du die \"Gefahr\" von etwas dir selbst unbewusst erklärst, weil du davor Angst hast, dann ist es wahrscheinlich eine emotionale Schlussfolgerung. Es ist nicht gefährlich weil du davor Angst hast und du bist nicht furchtbar nur weil du es vielleicht denkst.",
   "emotional_reasoning_explanation_2": "Es ist schwierig zu erkennen. Es braucht Übung um zu erkennen wenn dein emotionales Denken die Führung vor dem logischen übernimmt.",
   "emotional_reasoning_thought": "Ich fühle mich schuldig, also muss ich etwas angestellt haben.",
   "fortune_telling": "Zukunft Vorhersagen",
@@ -115,22 +115,22 @@
   "magnification_of_the_negative_thought": "Diese Woche habe ich gesund gegessen, aber ich war nicht Laufen.",
   "mind_reading": "Gedanken lesen",
   "mind_reading_explanation": "Wenn wir uns darüber Gedanken machen, was jemand anderes über uns denkt, versuchen wir Gedanken zu lesen. Bis jemand sagt was er denkt, kannst du nicht wissen was er denkt. Wieso vom Schlimmsten ausgehen?",
-  "mind_reading_thought": "Ich glaube ich war unverschämt zu George, er hast mich bestimmt.",
+  "mind_reading_thought": "Ich glaube ich war unverschämt zu George, er hasst mich bestimmt.",
   "minimization_of_the_positive": "Reduzierung vom Positiven",
-  "minimization_of_the_positive_explanation": "Wenn wir die guten Sachen, welche uns passieren nicht wertschätzen, reduzieren wir das Positive. Selbst wenn unser Tag nicht zu 100% wie geplant verlief, heißt nicht dass wir 60% welche gut verliefen ignorieren sollten.",
+  "minimization_of_the_positive_explanation": "Wenn wir die guten Sachen, welche uns passieren nicht wertschätzen, reduzieren wir das Positive. Selbst wenn unser Tag nicht zu 100% wie geplant verlief, heißt das nicht, dass wir die 60% welche gut verliefen ignorieren sollten.",
   "minimization_of_the_positive_thought": "Viele mochten meine Präsentation, aber ich stotterte bei der Einleitung, also war die Präsentation schlecht.",
   "other_blaming": "Andere Beschuldigen",
-  "other_blaming_explanation_1": "Wenn eine schlechte Situation die Schuld vom jemanden sein muss, beschuldigen wir Andere. Wenn du eine Prüfung nicht bestanden hast und du den Lehrer beschuldigst, verschwendest du deine Energie an der falschen Stelle. Jemand hat die die Vorfahrt genommen? du hupst, überholst and den Übertäter festsetzt, wie hilfst dir das? Dir wurde die Vorfahrt genommen und du Ärgerst dich!",
+  "other_blaming_explanation_1": "Wenn eine schlechte Situation die Schuld vom jemanden sein muss, beschuldigen wir Andere. Wenn du eine Prüfung nicht bestanden hast und du den Lehrer beschuldigst, verschwendest du deine Energie an der falschen Stelle. Jemand hat die die Vorfahrt genommen? Du hupst, überholst und den setzt den Übertäter fest, wie hilfst dir das? Dir wurde die Vorfahrt genommen und du ärgerst dich!",
   "other_blaming_explanation_2": "Das heißt nicht, dass du dich selbst beschuldigen solltest für jede negative Situation. Du musst niemanden beschuldigen. Niemand muss Schuld haben, wenn du die Situation hinter dir lässt ohne Schuld zuzuweisen.",
   "other_blaming_thought": "Der Depp braucht zu lange in der Schlange und ich werde mich verspäten!",
   "over_generalization": "Verallgemeinern",
   "over_generalization_explanation": "Wenn wir basierend auf einer Situation Schlüsse ziehen, verallgemeinern wir. Wenn du eine Präsentation schlecht gehalten hast und vermutest das heißt du bist \"schlecht\" beim Presentieren, bist du am Verallgemeinern.",
   "over_generalization_thought": "Niemand bat mich um einen Tanz, also wird nie jemals jemand mit mir Tanzen wollen.",
   "self_blaming": "Sich selbst Beschuldigen",
-  "self_blaming_explanation": "Wenn du dir eine negative Situation vollständig selbst zurechnest, beschuldigst du dich. Du bist nicht für jede negative Situation welche passiert verantwortlich. Wenn du in einen Stau gerätst und dich selbst nieder machst weil du nicht früher Losgefahren bist, beschuldigst du dich selbst. Würdest du jemand anderes so behandeln?",
+  "self_blaming_explanation": "Wenn du dir eine negative Situation vollständig selbst zurechnest, beschuldigst du dich. Du bist nicht für jede negative Situation welche passiert verantwortlich. Wenn du in einen Stau gerätst und dich selbst nieder machst weil du nicht früher losgefahren bist, beschuldigst du dich selbst. Würdest du jemand anderes so behandeln?",
   "self_blaming_thought": "Mein Sohn fällt in der Schule durch, ich war nicht für ihn da.",
   "should_statements": "Sollte Aussagen",
-  "should_statements_explanation_1": "Wenn du jemanden nicht vorhandene Fähigkeiten zusprichst, benutzt du falsche \"sollte\" Aussagen. Als Beispiel, wenn du Flugangst hast und dir selbst einredest \"Ich sollte nicht Angst haben, es ist nichts falsch mir dem Flugzeug!\" legst du eine unnötige Last auf dich. Du hast Flugangst! Es ist normal für Menschen welche Angst vor dem Fliegen haben Angst beim Fliegen zu haben!",
+  "should_statements_explanation_1": "Wenn du jemanden nicht vorhandene Fähigkeiten zusprichst, benutzt du falsche \"sollte\" Aussagen. Als Beispiel, wenn du Flugangst hast und dir selbst einredest \"Ich sollte nicht Angst haben, es ist nichts falsch mit dem Flugzeug!\" legst du eine unnötige Last auf dich. Du hast Flugangst! Es ist normal für Menschen welche Angst vor dem Fliegen haben Angst beim Fliegen zu haben!",
   "should_statements_explanation_2": "Sollte Aussagen klingen manchmal unsinnig, wenn du diese Laut aussprichst; das ist der Punkt! Sie sind unlogisch!",
   "should_statements_thought": "Ich bin Erwachsen, ich sollte diese mentalen Probleme nicht haben."
 }


### PR DESCRIPTION
I found some grammatical issues within the german translations and fixed them.
I also noticed that the german translation uses a `line2` item within the `onboarding_screen.thoughts_arent_thoughts` and `onboarding_screen.your_distorted` parts, but this parts are never used in `CBTOnBoarding.tsx`.
I added the two lines, but the other languages don't use those lines and don't provide translations for it and I'm not sure how the `i18n` module handles not existing translation strings. Unfortunately, I was n't able to get the app running on my machine to test this.
If the fallback is an empty string this shouldn't be a problem, but if the fallback would be the translation key I will have to change it. Then I would need to add a `line2` item to every other language or I would have to change the two sentences, so no `line2` item would be needed.
Please provide me with your prefered action.